### PR TITLE
feat: ability to add custom message to jest errors

### DIFF
--- a/.bin/test.js
+++ b/.bin/test.js
@@ -1,7 +1,0 @@
-require('@adonisjs/require-ts/build/register')
-
-const { configure } = require('japa')
-
-configure({
-  files: ['test/**/*.spec.ts'],
-})

--- a/bin/test.ts
+++ b/bin/test.ts
@@ -1,0 +1,34 @@
+import { assert } from '@japa/assert'
+import { specReporter } from '@japa/spec-reporter'
+import { processCliArgs, configure, run } from '@japa/runner'
+
+/*
+|--------------------------------------------------------------------------
+| Configure tests
+|--------------------------------------------------------------------------
+|
+| The configure method accepts the configuration to configure the Japa
+| tests runner.
+|
+| The first method call "processCliArgs" process the command line arguments
+| and turns them into a config object. Using this method is not mandatory.
+|
+| Please consult japa.dev/runner-config for the config docs.
+*/
+configure({
+  ...processCliArgs(process.argv.slice(2)),
+  files: ['tests/**/*.spec.ts'],
+  plugins: [assert()],
+  reporters: [specReporter()],
+  importer: (filePath) => import(filePath),
+})
+
+/*
+|--------------------------------------------------------------------------
+| Run tests
+|--------------------------------------------------------------------------
+|
+| The following "run" method is required to execute all the tests.
+|
+*/
+run()

--- a/index.ts
+++ b/index.ts
@@ -7,18 +7,21 @@
  * file that was distributed with this source code.
  */
 
-import { default as jestExpect } from 'expect'
 import type { PluginFn } from '@japa/runner'
+import { jestExpectWithMessage } from './src/with_message/index'
+import { PluginOptions } from './src/types'
 
 /**
  * Jest expect type
  */
-export type Expect = typeof jestExpect
+export type Expect = ReturnType<typeof jestExpectWithMessage>
 
 /**
  * Expect plugin for "@japa/runner"
  */
-export function expect(): PluginFn {
+export function expect(options?: PluginOptions): PluginFn {
+  const jestExpect = jestExpectWithMessage(options?.messages)
+
   return function (_, __, { TestContext, Test }) {
     TestContext.getter('expect', () => jestExpect, true)
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "mrm": "mrm --preset=@adonisjs/mrm-preset",
     "pretest": "npm run lint",
-    "test": "node .bin/test.js",
+    "test": "node -r @adonisjs/require-ts/build/register ./bin/test.ts",
     "clean": "del build",
     "compile": "npm run lint && npm run clean && tsc",
     "build": "npm run compile",
@@ -35,7 +35,9 @@
   "devDependencies": {
     "@adonisjs/mrm-preset": "^5.0.3",
     "@adonisjs/require-ts": "^2.0.13",
+    "@japa/assert": "^1.4.1",
     "@japa/runner": "^2.2.3",
+    "@japa/spec-reporter": "^1.3.3",
     "@types/node": "^18.13.0",
     "commitizen": "^4.3.0",
     "cz-conventional-changelog": "^3.3.0",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,26 @@
+export interface JestExpectWithMessageOptions {
+  /**
+   * If false will not show the `Custom message`: prefix.
+   * @default true
+   */
+  showPrefix?: boolean
+
+  /**
+   * If false will not show the matchers original error message.
+   * @default true
+   */
+  showMatcherMessage?: boolean
+
+  /**
+   * If false will not show the stack trace.
+   * @default true
+   */
+  showStack?: boolean
+}
+
+/**
+ * Types for @japa/expect plugin configuration
+ */
+export interface PluginOptions {
+  messages?: JestExpectWithMessageOptions
+}

--- a/src/with_message/assertion_error.ts
+++ b/src/with_message/assertion_error.ts
@@ -1,0 +1,16 @@
+export class JestAssertionError extends Error {
+  public matcherResult: any
+
+  constructor(
+    result: { message: string | (() => string | undefined) | undefined },
+    callsite: Function | undefined
+  ) {
+    super(typeof result.message === 'function' ? result.message() : result.message)
+
+    this.matcherResult = result
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, callsite)
+    }
+  }
+}

--- a/src/with_message/index.ts
+++ b/src/with_message/index.ts
@@ -1,0 +1,34 @@
+import { default as baseJestExpect } from 'expect'
+import type { JestExpectWithMessageOptions } from '../types'
+import { MatcherWrapper } from './matcher_wrapper'
+
+export function jestExpectWithMessage(options: JestExpectWithMessageOptions = {}) {
+  const baseConfig = {
+    showMatcherMessage: options.showMatcherMessage ?? true,
+    showPrefix: options.showPrefix ?? false,
+    showStack: options.showStack ?? true,
+  }
+
+  let expectProxy = Object.assign(
+    (actual: unknown, customMessage?: string, proxyOptions?: JestExpectWithMessageOptions) => {
+      const config = { ...baseConfig, ...(proxyOptions || {}) }
+
+      // partially apply expect to get all matchers and chain them
+      let matchers = baseJestExpect(actual)
+      if (customMessage) {
+        // only pay the cost of proxying matchers if we received a customMessage
+        matchers = MatcherWrapper.wrapMatchers(matchers, customMessage, config)
+      }
+
+      return matchers
+    },
+    baseJestExpect // clone additional properties on expect
+  )
+
+  expectProxy.extend = (o) => {
+    baseJestExpect.extend(o) // add new matchers to expect
+    expectProxy = Object.assign(expectProxy, baseJestExpect) // clone new asymmetric matchers
+  }
+
+  return expectProxy
+}

--- a/src/with_message/matcher_wrapper.ts
+++ b/src/with_message/matcher_wrapper.ts
@@ -1,0 +1,87 @@
+import { JestExpectWithMessageOptions } from '../types'
+import { JestAssertionError } from './assertion_error'
+
+export class MatcherWrapper {
+  private static rethrowWithMessage(
+    error: any,
+    customMessage: string,
+    config: JestExpectWithMessageOptions,
+    newMatcher: Function
+  ) {
+    if (!error.matcherResult) {
+      throw error
+    }
+    const { matcherResult } = error
+
+    if (typeof customMessage !== 'string' || customMessage.length < 1) {
+      throw new JestAssertionError(matcherResult, newMatcher)
+    }
+
+    const matcherMessage =
+      typeof error.matcherResult.message === 'function'
+        ? error.matcherResult.message()
+        : error.matcherResult.message
+
+    const messagePrefix = config.showPrefix ? '\n    Custom message:\n      ' : ''
+
+    const message = () =>
+      messagePrefix + customMessage + (config.showMatcherMessage ? '\n\n' + matcherMessage : '')
+
+    const e = new JestAssertionError({ ...matcherResult, message }, newMatcher)
+
+    if (!config.showStack) {
+      e.stack = undefined
+    }
+
+    throw e
+  }
+
+  /**
+   * Return a wrapped version of a matcher that throws a custom message
+   */
+  private static wrapMatcher(
+    matcher: any,
+    customMessage: string,
+    config: JestExpectWithMessageOptions
+  ) {
+    const newMatcher = (...args: any) => {
+      try {
+        const result = matcher(...args)
+
+        if (!result || typeof result.then !== 'function') {
+          return result
+        }
+
+        return result
+          .catch((error: any) => this.rethrowWithMessage(error, customMessage, config, newMatcher))
+          .catch(function handleError(error) {
+            throw new JestAssertionError(error.matcherResult, handleError)
+          })
+      } catch (e) {
+        this.rethrowWithMessage(e, customMessage, config, newMatcher)
+      }
+    }
+    return newMatcher
+  }
+
+  /**
+   * Replace all matchers with wrapped versions that throw a custom message
+   */
+  public static wrapMatchers(
+    matchers: any,
+    customMessage: string,
+    config: JestExpectWithMessageOptions
+  ): any {
+    return Object.keys(matchers).reduce((acc, name) => {
+      const matcher = matchers[name]
+
+      if (typeof matcher === 'function') {
+        acc[name] = this.wrapMatcher(matcher, customMessage, config)
+      } else {
+        acc[name] = this.wrapMatchers(matcher, customMessage, config) // recurse on .not/.resolves/.rejects
+      }
+
+      return acc
+    }, {})
+  }
+}

--- a/tests/with_message.spec.ts
+++ b/tests/with_message.spec.ts
@@ -1,0 +1,67 @@
+import { test } from '@japa/runner'
+import { jestExpectWithMessage } from '../src/with_message/index'
+
+function removeAnsiCodes(str: string) {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\u001b\[[0-9;]*m/g, '')
+}
+
+test.group('With Message', () => {
+  test('Throws a custom message when matcher fails', ({ assert }) => {
+    assert.plan(1)
+    const expect = jestExpectWithMessage()
+
+    try {
+      expect(2 + 2, 'Should be equal to 4 !!').toBe(5)
+    } catch (e) {
+      assert.include(e.message, 'Should be equal to 4 !!')
+    }
+  })
+
+  test('Throws original matcher message when not custom message is provided', ({ assert }) => {
+    assert.plan(1)
+    const expect = jestExpectWithMessage()
+
+    try {
+      expect(2 + 2).toBe(5)
+    } catch (e) {
+      const message = removeAnsiCodes(e.message)
+      assert.include(message, 'Expected: 5\nReceived: 4')
+    }
+  })
+
+  test('show prefix when showPrefix is true', ({ assert }) => {
+    assert.plan(2)
+    const expect = jestExpectWithMessage({ showPrefix: true })
+
+    try {
+      expect(2 + 2, 'Should be equal to 4 !!').toBe(5)
+    } catch (e) {
+      assert.include(e.message, 'Custom message:\n')
+      assert.include(e.message, 'Should be equal to 4 !!')
+    }
+  })
+
+  test('config defined on test-level should override global config', ({ assert }) => {
+    assert.plan(2)
+    const expect = jestExpectWithMessage({ showPrefix: true })
+
+    try {
+      expect(2 + 2, 'Should be equal to 4 !!', { showPrefix: false }).toBe(5)
+    } catch (e) {
+      assert.notInclude(e.message, 'Custom message:\n')
+      assert.include(e.message, 'Should be equal to 4 !!')
+    }
+  })
+
+  test("shouldn't show stack when showStack is false", ({ assert }) => {
+    assert.plan(1)
+    const expect = jestExpectWithMessage({ showStack: false })
+
+    try {
+      expect(2 + 2, 'Should be equal to 4 !!').toBe(5)
+    } catch (e) {
+      assert.isUndefined(e.stack)
+    }
+  })
+})


### PR DESCRIPTION
Hey!

As discussed, here is a PR that allows you to add custom messages for jest matchers.

So, I finally took most of the [jest-expect-message](https://github.com/mattphillips/jest-expect-message) code but adapted some things to match better with Japa. Since it was a very small package I also thought it would be more convenient to have a hand on the whole code. 

## Plugin Configuration

In our bin/test.ts configuration file we can pass several configuration parameters to `expect`: 
```ts
  plugins: [
    expect({
      messages: {
        showMatcherMessage: true,
        showPrefix: true,
        showStack: true,
      },
    }),
  ],
  ```

These options are exactly the same as those proposed by jest-expect-message, [here we can see a small summary](https://github.com/mattphillips/jest-expect-message#usage) of what these different options do
  
## Usage

```ts
test("Maths.add", ({ expect }) => {
  expect(1 + 1, "Should be equal to 2").toBe(3);
});
```

We can also specify the options seen above but at the level of each test. The options specified at the test-level will take priority over the options defined at the plugin-level : 

```ts
test("Maths.add", ({ expect }) => {
  expect(1 + 1, "Should be equal to 2222", { showStack: false }).toBe(3);
});
```

This is what it looks like with `showMatcherMessage: false` and `showPrefix: false`
![image](https://user-images.githubusercontent.com/8337858/227779575-050b2de2-7149-4764-b6bf-58c90854375f.png)


## Further comments

If accepted I will add the necessary documentation on japa.dev 

---

Let me know if anything looks wrong or needs to be changed 👍 